### PR TITLE
Add return type

### DIFF
--- a/src/Singleton.php
+++ b/src/Singleton.php
@@ -13,7 +13,10 @@ trait Singleton
 	{
 		throw new Exception('You can not clone a singleton.');
 	}
-
+	
+	/**
+	* @return static
+	*/
 	public static function getInstance()
 	{
     	static $instances;


### PR DESCRIPTION
When we return the return type of getInstance() IDEs can determine the returnes class and thus provide auto-complete information