### PR TITLE
Add comprehensive documentation structure for Singleton pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@
 A lightweight PHP implementation of the Design Pattern Singleton using trait.
 Just one class and no dependencies.
 
+## Documentation
+
+- [Getting Started](docs/getting-started.md) - Installation and requirements
+- [Creating a Singleton Class](docs/creating-singleton.md) - How to implement the pattern
+- [Using Your Singleton](docs/using-singleton.md) - Working with singleton instances
+- [How It Works](docs/how-it-works.md) - Implementation details
+- [API Reference](docs/api-reference.md) - Complete API documentation
+
 ## Requirements
 
 PHP 8.3 or higher
@@ -81,17 +89,18 @@ The `Singleton` trait:
 - Implements the `getInstance()` static method to create and manage a single instance
 - Prevents cloning by overriding the `__clone()` method
 - Prevents serialization and deserialization by overriding `__sleep()` and `__wakeup()`
-- Uses a static property to store instances of each class that uses the trait
+- Uses a static local variable within `getInstance()` to store instances of each class that uses the trait
 
 ## Run Tests
 
-```
+```bash
 vendor/bin/phpunit
 ```
 
 ## References
 
-* https://en.wikipedia.org/wiki/Singleton_pattern
+* [Wikipedia: Singleton Pattern](https://en.wikipedia.org/wiki/Singleton_pattern)
+* [Documentation](docs/getting-started.md)
 
 ## Dependencies
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,200 @@
+---
+sidebar_position: 5
+---
+
+# API Reference
+
+## Singleton Trait
+
+**Namespace:** `ByJG\DesignPattern`
+
+The `Singleton` trait provides a complete implementation of the Singleton design pattern.
+
+### Methods
+
+#### getInstance()
+
+```php
+public static function getInstance(): static
+```
+
+Returns the singleton instance of the class. Creates the instance on first call.
+
+**Returns:** The singleton instance of the calling class
+
+**Example:**
+```php
+$instance = MyClass::getInstance();
+```
+
+#### __construct()
+
+```php
+protected function __construct()
+```
+
+Protected constructor to prevent direct instantiation. Override this in your class with a private or protected constructor.
+
+**Note:** Should be overridden as `private` or `protected` in implementing classes.
+
+#### __clone()
+
+```php
+public function __clone()
+```
+
+Prevents cloning of the singleton instance.
+
+**Throws:** `ByJG\DesignPattern\SingletonException` - Always throws when clone is attempted
+
+**Example:**
+```php
+try {
+    $cloned = clone $instance;
+} catch (\ByJG\DesignPattern\SingletonException $e) {
+    // Handle exception
+}
+```
+
+#### __sleep()
+
+```php
+public function __sleep()
+```
+
+Prevents serialization of the singleton instance.
+
+**Throws:** `ByJG\DesignPattern\SingletonException` - Always throws when serialization is attempted
+
+**Example:**
+```php
+try {
+    $serialized = serialize($instance);
+} catch (\ByJG\DesignPattern\SingletonException $e) {
+    // Handle exception
+}
+```
+
+#### __wakeup()
+
+```php
+public function __wakeup()
+```
+
+Prevents unserialization of the singleton instance.
+
+**Throws:** `ByJG\DesignPattern\SingletonException` - Always throws when unserialization is attempted
+
+**Example:**
+```php
+try {
+    $instance = unserialize($data);
+} catch (\ByJG\DesignPattern\SingletonException $e) {
+    // Handle exception
+}
+```
+
+## SingletonException
+
+**Namespace:** `ByJG\DesignPattern`
+**Extends:** `Exception`
+
+Exception thrown when attempting prohibited operations on a singleton instance.
+
+### When It's Thrown
+
+This exception is thrown in the following scenarios:
+
+1. **Cloning attempt** - When trying to clone a singleton instance
+2. **Serialization attempt** - When trying to serialize a singleton instance
+3. **Unserialization attempt** - When trying to unserialize a singleton instance
+
+### Properties
+
+Inherits all properties from the standard PHP `Exception` class:
+
+- `$message` - The exception message
+- `$code` - The exception code
+- `$file` - The filename where the exception was thrown
+- `$line` - The line number where the exception was thrown
+
+### Example
+
+```php
+use ByJG\DesignPattern\SingletonException;
+
+try {
+    $cloned = clone MyClass::getInstance();
+} catch (SingletonException $e) {
+    echo "Error: " . $e->getMessage();
+    // Output: Error: You can not clone a singleton.
+}
+```
+
+## Usage Example
+
+Complete example showing all API features:
+
+```php
+<?php
+require "vendor/autoload.php";
+
+use ByJG\DesignPattern\Singleton;
+use ByJG\DesignPattern\SingletonException;
+
+class Logger
+{
+    use Singleton;
+
+    private array $logs = [];
+
+    private function __construct()
+    {
+        // Initialize logger
+    }
+
+    public function log(string $message): void
+    {
+        $this->logs[] = [
+            'time' => time(),
+            'message' => $message
+        ];
+    }
+
+    public function getLogs(): array
+    {
+        return $this->logs;
+    }
+}
+
+// Get instance
+$logger = Logger::getInstance();
+$logger->log("Application started");
+
+// Same instance is returned
+$sameLogger = Logger::getInstance();
+echo count($sameLogger->getLogs()); // Output: 1
+
+// These operations throw SingletonException:
+try {
+    clone $logger;
+} catch (SingletonException $e) {
+    echo $e->getMessage(); // You can not clone a singleton.
+}
+
+try {
+    serialize($logger);
+} catch (SingletonException $e) {
+    echo $e->getMessage(); // You can not serialize a singleton.
+}
+```
+
+## Type Safety
+
+The trait uses the `static` return type for `getInstance()`, which provides proper type hinting in IDEs:
+
+```php
+// IDE knows $logger is of type Logger, not just Singleton
+$logger = Logger::getInstance();
+$logger->log("test"); // IDE autocomplete works correctly
+```

--- a/docs/creating-singleton.md
+++ b/docs/creating-singleton.md
@@ -1,0 +1,89 @@
+---
+sidebar_position: 2
+---
+
+# Creating a Singleton Class
+
+## Basic Implementation
+
+To create a singleton class, use the `Singleton` trait and ensure your constructor is private or protected:
+
+```php
+<?php
+class Example
+{
+    // Use the Singleton trait to implement the pattern
+    use \ByJG\DesignPattern\Singleton;
+
+    // You can add properties to your singleton
+    public string $someProperty;
+
+    // The constructor MUST be private or protected
+    private function __construct()
+    {
+        // Optional initialization code
+        $this->someProperty = "Initial value";
+    }
+
+    // Add your own methods and properties here
+    public function doSomething(): void
+    {
+        // Your code here
+    }
+}
+```
+
+## Important Rules
+
+:::danger Constructor Visibility
+Your class **MUST** use a private or protected constructor. If the constructor is public, the singleton pattern will be broken as users could create multiple instances directly.
+:::
+
+:::warning No Constructor Arguments
+Singleton classes do not accept arguments in the constructor. Use setter methods or configure the instance after retrieval if you need to customize it.
+:::
+
+:::info Protected Operations
+Attempting to clone, serialize, or unserialize a singleton will throw a `SingletonException`.
+:::
+
+## Real-World Example
+
+```php
+<?php
+class DatabaseConnection
+{
+    use \ByJG\DesignPattern\Singleton;
+
+    private $connection;
+
+    private function __construct()
+    {
+        // Establish database connection once
+        $this->connection = new PDO(
+            'mysql:host=localhost;dbname=mydb',
+            'user',
+            'password'
+        );
+    }
+
+    public function query(string $sql): array
+    {
+        return $this->connection->query($sql)->fetchAll();
+    }
+}
+```
+
+## What You Get
+
+When you use the `Singleton` trait, you automatically get:
+
+- **getInstance()** - Static method to retrieve the single instance
+- **Clone protection** - `__clone()` throws `SingletonException`
+- **Serialization protection** - `__sleep()` throws `SingletonException`
+- **Unserialization protection** - `__wakeup()` throws `SingletonException`
+
+## Next Steps
+
+- [Using Your Singleton](using-singleton.md)
+- [API Reference](api-reference.md)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,49 @@
+---
+sidebar_position: 1
+---
+
+# Getting Started
+
+## Requirements
+
+PHP 8.3 or higher
+
+## Installation
+
+Install the package via Composer:
+
+```bash
+composer require "byjg/singleton-pattern"
+```
+
+This package has no external dependencies - just one trait and one exception class.
+
+## What is the Singleton Pattern?
+
+The Singleton pattern is a design pattern that restricts the instantiation of a class to a single instance. This is useful when exactly one object is needed to coordinate actions across the system.
+
+## Quick Example
+
+```php
+<?php
+require "vendor/autoload.php";
+
+class MyConfig
+{
+    use \ByJG\DesignPattern\Singleton;
+
+    private function __construct()
+    {
+        // Load configuration
+    }
+}
+
+// Get the single instance
+$config = MyConfig::getInstance();
+```
+
+## Next Steps
+
+- [Creating a Singleton Class](creating-singleton.md)
+- [Using Your Singleton](using-singleton.md)
+- [How It Works](how-it-works.md)

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -1,0 +1,145 @@
+---
+sidebar_position: 4
+---
+
+# How It Works
+
+## Implementation Details
+
+The `Singleton` trait provides a complete singleton implementation through several key mechanisms:
+
+### Instance Storage
+
+The trait uses a static local variable within the `getInstance()` method to store instances:
+
+```php
+public static function getInstance(): static
+{
+    static $instances;
+
+    $calledClass = get_called_class();
+
+    if (!isset($instances[$calledClass])) {
+        $instances[$calledClass] = new $calledClass();
+    }
+    return $instances[$calledClass];
+}
+```
+
+This approach allows the trait to manage separate instances for each class that uses it. The `$instances` array is keyed by the class name, ensuring that each class gets its own singleton instance.
+
+### Protected Constructor
+
+The trait provides a protected constructor:
+
+```php
+protected function __construct()
+{
+    // Constructor cannot be public
+}
+```
+
+Classes using the trait should override this with their own private or protected constructor to prevent direct instantiation.
+
+### Clone Prevention
+
+The `__clone()` magic method is overridden to prevent cloning:
+
+```php
+public function __clone()
+{
+    throw new SingletonException('You can not clone a singleton.');
+}
+```
+
+### Serialization Prevention
+
+The `__sleep()` magic method prevents serialization:
+
+```php
+public function __sleep()
+{
+    throw new SingletonException('You can not serialize a singleton.');
+}
+```
+
+### Unserialization Prevention
+
+The `__wakeup()` magic method prevents unserialization:
+
+```php
+public function __wakeup()
+{
+    throw new SingletonException('You can not deserialize a singleton.');
+}
+```
+
+## Why Use a Trait?
+
+Using a trait for the Singleton pattern offers several advantages:
+
+1. **Reusability** - Apply the pattern to any class without inheritance
+2. **No Base Class Required** - Your singleton can extend other classes if needed
+3. **Clean Separation** - Pattern implementation is separate from business logic
+4. **Type Safety** - Returns `static` type for proper IDE support
+
+## Class Hierarchy Support
+
+Because this implementation uses a trait rather than a base class, your singleton can extend other classes:
+
+```php
+class BaseService
+{
+    protected function log(string $message): void
+    {
+        // Logging logic
+    }
+}
+
+class MyService extends BaseService
+{
+    use \ByJG\DesignPattern\Singleton;
+
+    private function __construct()
+    {
+        $this->log("Service initialized");
+    }
+}
+```
+
+## Multiple Singleton Classes
+
+Each class that uses the `Singleton` trait gets its own independent instance:
+
+```php
+class ConfigManager
+{
+    use \ByJG\DesignPattern\Singleton;
+    private function __construct() {}
+}
+
+class DatabaseManager
+{
+    use \ByJG\DesignPattern\Singleton;
+    private function __construct() {}
+}
+
+// These are completely separate instances
+$config = ConfigManager::getInstance();
+$db = DatabaseManager::getInstance();
+```
+
+## Limitations
+
+:::warning Constructor Arguments
+The singleton pattern as implemented does not support constructor arguments. This is by design - the first call to `getInstance()` has no arguments to pass. If you need configuration, use setter methods after getting the instance.
+:::
+
+:::info No Lazy Initialization Control
+The instance is created on the first call to `getInstance()`. There's no mechanism to delay instantiation further or pre-initialize instances.
+:::
+
+## Next Steps
+
+- [API Reference](api-reference.md)
+- [Creating a Singleton Class](creating-singleton.md)

--- a/docs/using-singleton.md
+++ b/docs/using-singleton.md
@@ -1,0 +1,93 @@
+---
+sidebar_position: 3
+---
+
+# Using Your Singleton
+
+## Getting the Instance
+
+Use the static `getInstance()` method to retrieve the singleton instance:
+
+```php
+// Get the singleton instance
+$example = Example::getInstance();
+```
+
+## Instance Persistence
+
+The same instance is always returned, ensuring singleton behavior:
+
+```php
+// Get the singleton instance
+$example = Example::getInstance();
+
+// Get another reference to the same instance
+$anotherReference = Example::getInstance();
+
+// Modify the property
+$example->someProperty = "Changed value";
+
+// This will output "Changed value" because both variables reference the same instance
+echo $anotherReference->someProperty; // Output: Changed value
+```
+
+## What You Cannot Do
+
+### Cloning is Prohibited
+
+Attempting to clone a singleton instance will throw a `SingletonException`:
+
+```php
+try {
+    $cloned = clone $example;
+} catch (\ByJG\DesignPattern\SingletonException $e) {
+    echo "Cannot clone a singleton!";
+}
+```
+
+### Serialization is Prohibited
+
+Attempting to serialize a singleton will throw a `SingletonException`:
+
+```php
+try {
+    $serialized = serialize($example);
+} catch (\ByJG\DesignPattern\SingletonException $e) {
+    echo "Cannot serialize a singleton!";
+}
+```
+
+### Unserialization is Prohibited
+
+Attempting to unserialize a singleton will throw a `SingletonException`:
+
+```php
+try {
+    $unserialized = unserialize($someSerialized Data);
+} catch (\ByJG\DesignPattern\SingletonException $e) {
+    echo "Cannot deserialize a singleton!";
+}
+```
+
+## Best Practices
+
+:::tip Use for Shared State
+Singletons are ideal for managing shared state or resources, such as:
+- Database connections
+- Configuration objects
+- Logging services
+- Cache managers
+:::
+
+:::warning Thread Safety
+This implementation is not thread-safe in multi-threaded environments. For such cases, consider using proper locking mechanisms.
+:::
+
+:::caution Testing Considerations
+Singletons can make unit testing more difficult because they maintain state across tests. Consider using dependency injection for better testability.
+:::
+
+## Next Steps
+
+- [How It Works](how-it-works.md)
+- [API Reference](api-reference.md)


### PR DESCRIPTION
- Introduced detailed markdown-based documentation in the `docs` folder.
- Topics include "Getting Started," "Creating a Singleton Class," "Using Your Singleton," "How It Works," and "API Reference."
- Updated `README.md` to link to the newly added documentation.